### PR TITLE
Do not ignore NewClient error in example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,11 @@ type Config struct {
 var client connect.Client
 
 func main() {
-	client, _ := connect.NewClientFromEnvironment()
-
+	client, err := connect.NewClientFromEnvironment()
+	if err != nil {
+		panic(err)
+	}
+	
 	connect.Load(client, &c)
 }
 


### PR DESCRIPTION
Having the error being ignored, is a bad example. From the code example itself, it is not directly clear that it is an error that is ignored. Writing it this way, makes this clearer.