### PR TITLE
Add function to check Connect server compatibility

### DIFF
--- a/connect/version.go
+++ b/connect/version.go
@@ -1,5 +1,102 @@
 package connect
 
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
 // SDKVersion is the latest Semantic Version of the library
 // Do not rename this variable without changing the regex in the Makefile
 const SDKVersion = "1.1.0"
+
+// expectMinimumConnectVersion returns an error if the provided minimum version for Connect is lower than the version
+// reported in the response from Connect.
+func expectMinimumConnectVersion(resp *http.Response, minimumVersion version) error {
+	serverVersion, err := getServerVersion(resp)
+	if err != nil {
+		// Return gracefully if server version cannot be determined reliably
+		return nil
+	}
+	if !serverVersion.IsGreaterOrEqualThan(minimumVersion) {
+		return fmt.Errorf("need at least version %s of Connect for this function, detected version %s. Please update your Connect server", minimumVersion, serverVersion)
+	}
+	return nil
+}
+
+func getServerVersion(resp *http.Response) (serverVersion, error) {
+	versionHeader := resp.Header.Get("1Password-Connect-Version")
+	if versionHeader == "" {
+		// The last version without the version header was v1.2.0
+		return serverVersion{
+			version:   version{1, 2, 0},
+			orEarlier: true,
+		}, nil
+	}
+	return parseServerVersion(versionHeader)
+}
+
+type version struct {
+	major int
+	minor int
+	patch int
+}
+
+// serverVersion describes the version reported by the server.
+type serverVersion struct {
+	version
+	// orEarlier is true if the version is derived from the lack of a version header from the server.
+	orEarlier bool
+}
+
+func (v version) String() string {
+	return fmt.Sprintf("%d.%d.%d", v.major, v.minor, v.patch)
+}
+
+func (v serverVersion) String() string {
+	if v.orEarlier {
+		return v.version.String() + " (or earlier)"
+	}
+	return v.version.String()
+}
+
+// IsGreaterOrEqualThan returns true if the lefthand-side version is equal to or or a higher version than the provided
+// minimum according to the semantic versioning rules.
+func (v version) IsGreaterOrEqualThan(min version) bool {
+	if v.major != min.major {
+		// Different major version
+		return v.major > min.major
+	}
+
+	if v.minor != min.minor {
+		// Same major, but different minor version
+		return v.minor > min.minor
+	}
+
+	// Same major and minor version
+	return v.patch >= min.patch
+}
+
+func parseServerVersion(v string) (serverVersion, error) {
+	spl := strings.Split(v, ".")
+	if len(spl) != 3 {
+		return serverVersion{}, errors.New("wrong length")
+	}
+	var res [3]int
+	for i := range res {
+		tmp, err := strconv.Atoi(spl[i])
+		if err != nil {
+			return serverVersion{}, err
+		}
+		res[i] = tmp
+	}
+	return serverVersion{
+		version: version{
+			major: res[0],
+			minor: res[1],
+			patch: res[2],
+		},
+	}, nil
+}

--- a/connect/version_test.go
+++ b/connect/version_test.go
@@ -1,0 +1,141 @@
+package connect
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVersion_IsGreaterOrEqualThan(t *testing.T) {
+	cases := map[string]struct {
+		serverVersion  version
+		minimumVersion version
+		expected       bool
+	}{
+		"equal": {
+			serverVersion:  version{1, 2, 3},
+			minimumVersion: version{1, 2, 3},
+			expected:       true,
+		},
+		"lower major": {
+			serverVersion:  version{1, 2, 3},
+			minimumVersion: version{2, 2, 3},
+			expected:       false,
+		},
+		"higher major": {
+			serverVersion:  version{2, 0, 0},
+			minimumVersion: version{1, 2, 3},
+			expected:       true,
+		},
+		"higher minor": {
+			serverVersion:  version{1, 3, 0},
+			minimumVersion: version{1, 2, 3},
+			expected:       true,
+		},
+		"lower minor": {
+			serverVersion:  version{1, 1, 3},
+			minimumVersion: version{1, 2, 3},
+			expected:       false,
+		},
+		"higher patch": {
+			serverVersion:  version{1, 2, 4},
+			minimumVersion: version{1, 2, 3},
+			expected:       true,
+		},
+		"lower patch": {
+			serverVersion:  version{1, 2, 2},
+			minimumVersion: version{1, 2, 3},
+			expected:       false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.serverVersion.IsGreaterOrEqualThan(tc.minimumVersion))
+		})
+	}
+}
+
+func TestGetServerVersion(t *testing.T) {
+	cases := map[string]struct {
+		version           string
+		expectedVersion   version
+		expectedOrEarlier bool
+		expectErr         bool
+	}{
+		"header set": {
+			version:         "1.2.3",
+			expectedVersion: version{1, 2, 3},
+		},
+		"header not set": {
+			version:           "",
+			expectedVersion:   version{1, 2, 0},
+			expectedOrEarlier: true,
+		},
+		"malformed header": {
+			version:   "1111.2",
+			expectErr: true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			header := http.Header{}
+			header.Set("1Password-Connect-Version", tc.version)
+			resp := &http.Response{
+				Header: header,
+			}
+
+			res, err := getServerVersion(resp)
+			if tc.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.Equal(t, tc.expectedVersion, res.version)
+				assert.Equal(t, tc.expectedOrEarlier, res.orEarlier)
+			}
+		})
+	}
+
+}
+
+func TestExpectMinimumVersion(t *testing.T) {
+	cases := map[string]struct {
+		minimumVersion version
+		headerValue    string
+		expectErr      bool
+	}{
+		"above minimum version": {
+			minimumVersion: version{1, 2, 3},
+			headerValue:    "1.3.0",
+			expectErr:      false,
+		},
+		"below minimum version": {
+			minimumVersion: version{1, 2, 3},
+			headerValue:    "1.1.0",
+			expectErr:      true,
+		},
+		"illegal version provided": {
+			minimumVersion: version{1, 2, 3},
+			headerValue:    "a",
+			expectErr:      false,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			header := http.Header{}
+			header.Set("1Password-Connect-Version", tc.headerValue)
+			resp := &http.Response{
+				Header: header,
+			}
+
+			err := expectMinimumConnectVersion(resp, tc.minimumVersion)
+			if tc.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.Nil(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
`expectMinimumConnectVersion()` can be used in functions that require a certain of Connect to work. Instead of returning a 404, this will make sure a helpful error about upgrading Connect is returned.

This function is not yet used and therefore does not change anything to the usage of this package.