### PR TITLE
Add support for file downloading

### DIFF
--- a/connect/client.go
+++ b/connect/client.go
@@ -358,6 +358,9 @@ func (rs *restClient) GetFile(uuid string, itemUUID string, vaultUUID string) (*
 	if err != nil {
 		return nil, err
 	}
+	if err := expectMinimumConnectVersion(response, version{1, 3, 0}); err != nil {
+		return nil, err
+	}
 
 	var file onepassword.File
 	if err := parseResponse(response, http.StatusOK, &file); err != nil {
@@ -386,10 +389,15 @@ func (rs *restClient) GetFileContent(file *onepassword.File) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	if err := expectMinimumConnectVersion(response, version{1, 3, 0}); err != nil {
+		return nil, err
+	}
+
 	content, err := readResponseBody(response, http.StatusOK)
 	if err != nil {
 		return nil, err
 	}
+
 	file.SetContent(content)
 	return content, nil
 }

--- a/connect/client.go
+++ b/connect/client.go
@@ -35,6 +35,8 @@ type Client interface {
 	CreateItem(item *onepassword.Item, vaultUUID string) (*onepassword.Item, error)
 	UpdateItem(item *onepassword.Item, vaultUUID string) (*onepassword.Item, error)
 	DeleteItem(item *onepassword.Item, vaultUUID string) error
+	GetFile(fileUUID string, itemUUID string, vaultUUID string) (*onepassword.File, error)
+	GetFileContent(file *onepassword.File) ([]byte, error)
 }
 
 type httpClient interface {
@@ -340,6 +342,58 @@ func (rs *restClient) DeleteItem(item *onepassword.Item, vaultUUID string) error
 	return nil
 }
 
+// GetFile Get a specific File in a specified item.
+// This does not include the file contents. Call GetFileContent() to load the file's content.
+func (rs *restClient) GetFile(uuid string, itemUUID string, vaultUUID string) (*onepassword.File, error) {
+	span := rs.tracer.StartSpan("GetFile")
+	defer span.Finish()
+
+	itemURL := fmt.Sprintf("/v1/vaults/%s/items/%s/files/%s", vaultUUID, itemUUID, uuid)
+	request, err := rs.buildRequest(http.MethodGet, itemURL, http.NoBody, span)
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := rs.client.Do(request)
+	if err != nil {
+		return nil, err
+	}
+
+	var file onepassword.File
+	if err := parseResponse(response, http.StatusOK, &file); err != nil {
+		return nil, err
+	}
+
+	return &file, nil
+}
+
+// GetFileContent retrieves the file's content.
+// If the file's content have previously been fetched, those contents are returned without making another request.
+func (rs *restClient) GetFileContent(file *onepassword.File) ([]byte, error) {
+	if content, err := file.Content(); err == nil {
+		return content, nil
+	}
+
+	span := rs.tracer.StartSpan("GetFileContent")
+	defer span.Finish()
+
+	request, err := rs.buildRequest(http.MethodGet, file.ContentPath, http.NoBody, span)
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := rs.client.Do(request)
+	if err != nil {
+		return nil, err
+	}
+	content, err := readResponseBody(response, http.StatusOK)
+	if err != nil {
+		return nil, err
+	}
+	file.SetContent(content)
+	return content, nil
+}
+
 func (rs *restClient) buildRequest(method string, path string, body io.Reader, span opentracing.Span) (*http.Request, error) {
 	url := fmt.Sprintf("%s%s", rs.URL, path)
 
@@ -362,17 +416,9 @@ func (rs *restClient) buildRequest(method string, path string, body io.Reader, s
 }
 
 func parseResponse(resp *http.Response, expectedStatusCode int, result interface{}) error {
-	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := readResponseBody(resp, expectedStatusCode)
 	if err != nil {
 		return err
-	}
-	if resp.StatusCode != expectedStatusCode {
-		var errResp *onepassword.Error
-		if err := json.Unmarshal(body, &errResp); err != nil {
-			return fmt.Errorf("decoding error response: %s", err)
-		}
-		return errResp
 	}
 	if result != nil {
 		if err := json.Unmarshal(body, result); err != nil {
@@ -380,4 +426,20 @@ func parseResponse(resp *http.Response, expectedStatusCode int, result interface
 		}
 	}
 	return nil
+}
+
+func readResponseBody(resp *http.Response, expectedStatusCode int) ([]byte, error) {
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != expectedStatusCode {
+		var errResp *onepassword.Error
+		if err := json.Unmarshal(body, &errResp); err != nil {
+			return nil, fmt.Errorf("decoding error response: %s", err)
+		}
+		return nil, errResp
+	}
+	return body, nil
 }

--- a/connect/client_test.go
+++ b/connect/client_test.go
@@ -621,16 +621,6 @@ func generateFile() *onepassword.File {
 }
 
 func getFile(req *http.Request) (*http.Response, error) {
-	if requestFail {
-		json, _ := json.Marshal("Not found")
-		return &http.Response{
-			Status:     http.StatusText(http.StatusNotFound),
-			StatusCode: http.StatusNotFound,
-			Body:       ioutil.NopCloser(bytes.NewReader(json)),
-			Header:     req.Header,
-		}, nil
-	}
-
 	vaultUUID := ""
 	itemUUID := ""
 	excessPath := ""
@@ -646,16 +636,6 @@ func getFile(req *http.Request) (*http.Response, error) {
 }
 
 func getFileContent(req *http.Request) (*http.Response, error) {
-	if requestFail {
-		json, _ := json.Marshal("Invalid file")
-		return &http.Response{
-			Status:     http.StatusText(http.StatusBadRequest),
-			StatusCode: http.StatusBadRequest,
-			Body:       ioutil.NopCloser(bytes.NewReader(json)),
-			Header:     req.Header,
-		}, nil
-	}
-
 	fileUUID := ""
 	excessPath := ""
 	fmt.Sscanf(req.URL.Path, "/v1/files/%s%s", fileUUID, excessPath)

--- a/connect/client_test.go
+++ b/connect/client_test.go
@@ -28,12 +28,21 @@ var requestCount int
 var requestFail bool
 var testUserAgent string
 
+var testServerDefaultVersion = version{1, 3, 0}
+
 type mockClient struct {
 	Dofunc func(req *http.Request) (*http.Response, error)
 }
 
 func (mc *mockClient) Do(req *http.Request) (*http.Response, error) {
-	return mc.Dofunc(req)
+	resp, err := mc.Dofunc(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.Header.Get(VersionHeaderKey) == "" {
+		resp.Header.Set(VersionHeaderKey, testServerDefaultVersion.String())
+	}
+	return resp, nil
 }
 
 func TestMain(m *testing.M) {

--- a/connect/version.go
+++ b/connect/version.go
@@ -12,6 +12,8 @@ import (
 // Do not rename this variable without changing the regex in the Makefile
 const SDKVersion = "1.1.0"
 
+const VersionHeaderKey = "1Password-Connect-Version"
+
 // expectMinimumConnectVersion returns an error if the provided minimum version for Connect is lower than the version
 // reported in the response from Connect.
 func expectMinimumConnectVersion(resp *http.Response, minimumVersion version) error {
@@ -27,7 +29,7 @@ func expectMinimumConnectVersion(resp *http.Response, minimumVersion version) er
 }
 
 func getServerVersion(resp *http.Response) (serverVersion, error) {
-	versionHeader := resp.Header.Get("1Password-Connect-Version")
+	versionHeader := resp.Header.Get(VersionHeaderKey)
 	if versionHeader == "" {
 		// The last version without the version header was v1.2.0
 		return serverVersion{

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/google/uuid v1.1.2
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/stretchr/testify v1.7.0 // indirect
+	github.com/stretchr/testify v1.7.0
 	github.com/uber/jaeger-client-go v2.25.0+incompatible
 	github.com/uber/jaeger-lib v2.4.0+incompatible // indirect
 	go.uber.org/atomic v1.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -22,9 +22,7 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/onepassword/files.go
+++ b/onepassword/files.go
@@ -1,0 +1,49 @@
+package onepassword
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+type File struct {
+	ID          string       `json:"id"`
+	Name        string       `json:"name"`
+	Section     *ItemSection `json:"section,omitempty"`
+	Size        int          `json:"size"`
+	ContentPath string       `json:"content_path"`
+	content     []byte
+}
+
+func (f *File) UnmarshalJSON(data []byte) error {
+	var jsonFile struct {
+		ID          string       `json:"id"`
+		Name        string       `json:"name"`
+		Section     *ItemSection `json:"section,omitempty"`
+		Size        int          `json:"size"`
+		ContentPath string       `json:"content_path"`
+		Content     []byte       `json:"content,omitempty"`
+	}
+	if err := json.Unmarshal(data, &jsonFile); err != nil {
+		return err
+	}
+	f.ID = jsonFile.ID
+	f.Name = jsonFile.Name
+	f.Section = jsonFile.Section
+	f.Size = jsonFile.Size
+	f.ContentPath = jsonFile.ContentPath
+	f.content = jsonFile.Content
+	return nil
+}
+
+// Content returns the content of the file if they have been loaded and returns an error if they have not been loaded.
+// Use `client.GetFileContent(file *File)` instead to make sure the content is fetched automatically if not present.
+func (f *File) Content() ([]byte, error) {
+	if f.content == nil {
+		return nil, errors.New("file content not loaded")
+	}
+	return f.content, nil
+}
+
+func (f *File) SetContent(content []byte) {
+	f.content = content
+}

--- a/onepassword/items.go
+++ b/onepassword/items.go
@@ -65,6 +65,7 @@ type Item struct {
 
 	Sections []*ItemSection `json:"sections,omitempty"`
 	Fields   []*ItemField   `json:"fields,omitempty"`
+	Files    []*File        `json:"files,omitempty"`
 
 	LastEditedBy string    `json:"lastEditedBy,omitempty"`
 	CreatedAt    time.Time `json:"createdAt,omitempty"`


### PR DESCRIPTION
This allows users to download files stored in an item. To be used with the (soon-to-be-released) `v1.3.0` of Connect.

Usage:
```go
vaultID := "emces67b7xbik3k7bldhr67esm"
itemID := "2mte23izewqnl52lx6fok4fzlu"

client, err := connect.NewClientFromEnvironment()
if err != nil {
    return err
}

item, err := client.GetItem(itemID, vaultID)
if err != nil {
     return err
}
for _, f := range item.Files {
    fmt.Printf("Found a file named %s", f.Name)

    content, err := client.GetFileContent(f)
    if err != nil {
        return err
    }
    // Do something with content
}
```