### PR TITLE
Load to item from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,15 +52,13 @@ type Config struct {
 	APIKey   onepassword.Item `opvault:"7vs66j55o6md5btwcph272mva4" opitem:"API Key"`
 }
 
-var client connect.Client
-
 func main() {
 	client, err := connect.NewClientFromEnvironment()
 	if err != nil {
 		panic(err)
 	}
     	c := Config{}
-	err = client.LoadToConfig(&c)
+	err = client.LoadConfig(&c)
 }
 
 ```
@@ -69,7 +67,6 @@ Additionally, fields of the same item can be added to a struct at once, without 
 package main
 
 import "github.com/1Password/connect-sdk-go/connect"
-
 
 
 type Config struct {
@@ -83,9 +80,7 @@ func main () {
 		panic(err)
 	}
 	c := Config{}
-	err := client.LoadFromItemToConfig(&c, "item-title", "vault-uuid")
-
-
+	err = client.LoadConfigFromItem(&c, "item-title", "vault-uuid")
 }
 
 ```

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Users can define tags on a struct and have the `connect.Client` unmarshall item 
 
 #### Example Struct
 
-This example struct will retrieve 3 fields from one Item and a whole Item from another vault
+This example struct will retrieve 2 fields from one Item and a whole Item from another vault
 
 ```go
 package main
@@ -47,7 +47,6 @@ import (
 )
 
 type Config struct {
-	Database string           `opitem:"Demo TF Database" opfield:".database"`
 	Username string           `opitem:"Demo TF Database" opfield:".username"`
 	Password string           `opitem:"Demo TF Database" opfield:".password"`
 	APIKey   onepassword.Item `opvault:"7vs66j55o6md5btwcph272mva4" opitem:"API Key"`
@@ -60,12 +59,36 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	
-	connect.Load(client, &c)
+    c := Config{}
+	err = client.LoadToConfig(&c)
 }
 
 ```
+Additionally, fields of the same item can be added to a struct at once, without needing to specify the `opitem` or `opvault` tags:
+```go
+package main
 
+import "github.com/1Password/connect-sdk-go/connect"
+
+
+
+type Config struct {
+	Username string     `opfield:".username"`
+	Password string     `opfield:".password"`
+}
+
+func main () {
+	client, err := connect.NewClientFromEnvironment()
+    if err != nil {
+		panic(err)
+	}
+	c := Config{}
+	err := client.LoadFromItemToConfig(&c, "item-title", "vault-uuid")
+
+
+}
+
+```
 ### Model Objects
 
 The `onepassword.Item` model represents Items and `onepassword.Vault` represent Vaults in 1Password

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Users can define tags on a struct and have the `connect.Client` unmarshall item 
 - `opitem` – The title of the Item
 - `opfield` – The item field whose value should be retrieved
 
+All retrieved fields require at least the `opfield` and `opitem` tags, while all retrieved items require the `opitem` tag. Additionally, a custom vault can be specified by setting the `opvault` tag. In case this is not set, the SDK will use the value of the `OP_VAULT` environment variable as the default UUID.
+
 #### Example Struct
 
 This example struct will retrieve 2 fields from one item and a whole item from another vault:
@@ -80,7 +82,8 @@ func main () {
 		panic(err)
 	}
 	c := Config{}
-	err = client.LoadStructFromItem(&c, "item-title", "vault-uuid")
+	err = client.LoadStructFromItemByTitle(&c, "Demo TF Database", "7vs66j55o6md5btwcph272mva4") // retrieve using item title
+    err = client.LoadStructFromItem(&c, "4bc73kao58g2usb582ndn3w4", "7vs66j55o6md5btwcph272mva4") // retrieve using item uuid
 }
 ```
 ### Model Objects

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Users can define tags on a struct and have the `connect.Client` unmarshall item 
 
 #### Example Struct
 
-This example struct will retrieve 2 fields from one Item and a whole Item from another vault
+This example struct will retrieve 2 fields from one item and a whole item from another vault:
 
 ```go
 package main
@@ -58,7 +58,7 @@ func main() {
 		panic(err)
 	}
     	c := Config{}
-	err = client.LoadConfig(&c)
+	err = client.LoadStruct(&c)
 }
 
 ```
@@ -80,9 +80,8 @@ func main () {
 		panic(err)
 	}
 	c := Config{}
-	err = client.LoadConfigFromItem(&c, "item-title", "vault-uuid")
+	err = client.LoadStructFromItem(&c, "item-title", "vault-uuid")
 }
-
 ```
 ### Model Objects
 

--- a/connect/client.go
+++ b/connect/client.go
@@ -11,7 +11,7 @@ import (
 	"net/url"
 	"os"
 
-	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 	jaegerClientConfig "github.com/uber/jaeger-client-go/config"
 	"github.com/uber/jaeger-client-go/zipkin"
@@ -37,6 +37,8 @@ type Client interface {
 	DeleteItem(item *onepassword.Item, vaultUUID string) error
 	GetFile(fileUUID string, itemUUID string, vaultUUID string) (*onepassword.File, error)
 	GetFileContent(file *onepassword.File) ([]byte, error)
+	LoadFromItemToConfig(config interface{}, itemTitle string, vaultUUID string) error
+	LoadToConfig(config interface{}) error
 }
 
 type httpClient interface {
@@ -421,6 +423,86 @@ func (rs *restClient) buildRequest(method string, path string, body io.Reader, s
 	rs.tracer.Inject(span.Context(), opentracing.HTTPHeaders, opentracing.HTTPHeadersCarrier(request.Header))
 
 	return request, nil
+}
+
+func (rs *restClient) LoadFromItemToConfig(i interface{}, itemTitle string, vaultUUID string) error {
+	config, err := checkStruct(i)
+	if err != nil {
+		return err
+	}
+	t := config.Type()
+	item := parsedItem{}
+
+	for i := 0; i < t.NumField(); i++ {
+		value := config.Field(i)
+		field := t.Field(i)
+
+		if !value.CanSet() {
+			return fmt.Errorf("cannot load config into private fields")
+		}
+
+		item.vaultUUID = vaultUUID
+		item.itemTitle = itemTitle
+		item.fields = append(item.fields, &field)
+		item.values = append(item.values, &value)
+	}
+
+	if err := setValuesForTag(rs, &item); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Load Load configuration values based on strcut tag
+func (rs *restClient) LoadToConfig(i interface{}) error {
+	config, err := checkStruct(i)
+	if err != nil {
+		return err
+	}
+
+	t := config.Type()
+
+	// Multiple fields may be from a single item so we will collect them
+	items := map[string]parsedItem{}
+
+	// Fetch the Vault from the environment
+	vaultUUID, envVarFound := os.LookupEnv(envVaultVar)
+
+	for i := 0; i < t.NumField(); i++ {
+		value := config.Field(i)
+		field := t.Field(i)
+		tag := field.Tag.Get(itemTag)
+
+		if tag == "" {
+			continue
+		}
+
+		if !value.CanSet() {
+			return fmt.Errorf("Cannot load config into private fields")
+		}
+
+		itemVault, err := vaultUUIDForField(&field, vaultUUID, envVarFound)
+		if err != nil {
+			return err
+		}
+
+		key := fmt.Sprintf("%s/%s", itemVault, tag)
+		parsed := items[key]
+		parsed.vaultUUID = itemVault
+		parsed.itemTitle = tag
+		parsed.fields = append(parsed.fields, &field)
+		parsed.values = append(parsed.values, &value)
+		items[key] = parsed
+	}
+
+	for _, item := range items {
+		if err := setValuesForTag(rs, &item); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func parseResponse(resp *http.Response, expectedStatusCode int, result interface{}) error {

--- a/connect/client.go
+++ b/connect/client.go
@@ -37,8 +37,8 @@ type Client interface {
 	DeleteItem(item *onepassword.Item, vaultUUID string) error
 	GetFile(fileUUID string, itemUUID string, vaultUUID string) (*onepassword.File, error)
 	GetFileContent(file *onepassword.File) ([]byte, error)
-	LoadConfigFromItem(config interface{}, itemTitle string, vaultUUID string) error
-	LoadConfig(config interface{}) error
+	LoadStructFromItem(config interface{}, itemTitle string, vaultUUID string) error
+	LoadStruct(config interface{}) error
 }
 
 type httpClient interface {
@@ -426,7 +426,7 @@ func (rs *restClient) buildRequest(method string, path string, body io.Reader, s
 }
 
 // LoadConfigFromItem Load configuration values based on struct tag from one 1P item
-func (rs *restClient) LoadConfigFromItem(i interface{}, itemTitle string, vaultUUID string) error {
+func (rs *restClient) LoadStructFromItem(i interface{}, itemTitle string, vaultUUID string) error {
 	config, err := checkStruct(i)
 	if err != nil {
 		return err
@@ -456,7 +456,7 @@ func (rs *restClient) LoadConfigFromItem(i interface{}, itemTitle string, vaultU
 }
 
 // LoadConfig Load configuration values based on struct tag
-func (rs *restClient) LoadConfig(i interface{}) error {
+func (rs *restClient) LoadStruct(i interface{}) error {
 	config, err := checkStruct(i)
 	if err != nil {
 		return err

--- a/connect/client.go
+++ b/connect/client.go
@@ -37,8 +37,8 @@ type Client interface {
 	DeleteItem(item *onepassword.Item, vaultUUID string) error
 	GetFile(fileUUID string, itemUUID string, vaultUUID string) (*onepassword.File, error)
 	GetFileContent(file *onepassword.File) ([]byte, error)
-	LoadFromItemToConfig(config interface{}, itemTitle string, vaultUUID string) error
-	LoadToConfig(config interface{}) error
+	LoadConfigFromItem(config interface{}, itemTitle string, vaultUUID string) error
+	LoadConfig(config interface{}) error
 }
 
 type httpClient interface {
@@ -425,7 +425,8 @@ func (rs *restClient) buildRequest(method string, path string, body io.Reader, s
 	return request, nil
 }
 
-func (rs *restClient) LoadFromItemToConfig(i interface{}, itemTitle string, vaultUUID string) error {
+// LoadConfigFromItem Load configuration values based on struct tag from one 1P item
+func (rs *restClient) LoadConfigFromItem(i interface{}, itemTitle string, vaultUUID string) error {
 	config, err := checkStruct(i)
 	if err != nil {
 		return err
@@ -454,8 +455,8 @@ func (rs *restClient) LoadFromItemToConfig(i interface{}, itemTitle string, vaul
 	return nil
 }
 
-// Load Load configuration values based on strcut tag
-func (rs *restClient) LoadToConfig(i interface{}) error {
+// LoadConfig Load configuration values based on struct tag
+func (rs *restClient) LoadConfig(i interface{}) error {
 	config, err := checkStruct(i)
 	if err != nil {
 		return err

--- a/connect/config_helper.go
+++ b/connect/config_helper.go
@@ -19,6 +19,7 @@ const (
 
 type parsedItem struct {
 	vaultUUID string
+	itemUUID  string
 	itemTitle string
 	fields    []*reflect.StructField
 	values    []*reflect.Value
@@ -52,8 +53,14 @@ func vaultUUIDForField(field *reflect.StructField, vaultUUID string, envVaultFou
 	return vaultUUID, nil
 }
 
-func setValuesForTag(client Client, parsedItem *parsedItem) error {
-	item, err := client.GetItemByTitle(parsedItem.itemTitle, parsedItem.vaultUUID)
+func setValuesForTag(client Client, parsedItem *parsedItem, byTitle bool) error {
+	var item *onepassword.Item
+	var err error
+	if byTitle {
+		item, err = client.GetItemByTitle(parsedItem.itemTitle, parsedItem.vaultUUID)
+	} else {
+		item, err = client.GetItem(parsedItem.itemUUID, parsedItem.vaultUUID)
+	}
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This pull request serves two purposes:
* it implements `LoadConfigFromItem` function, which closes #28 
* it refactors the `config.go` file, such that, now, the `LoadConfig` and `LoadConfigFromItem` functions have a Client as a receiver

The documentation has been also updated accordingly.