### PR TITLE
Implement missing file support methods (GetFiles and DownloadFile)

### DIFF
--- a/connect/client.go
+++ b/connect/client.go
@@ -41,7 +41,7 @@ type Client interface {
 	GetFiles(itemUUID string, vaultUUID string) ([]onepassword.File, error)
 	GetFile(fileUUID string, itemUUID string, vaultUUID string) (*onepassword.File, error)
 	GetFileContent(file *onepassword.File) ([]byte, error)
-	DownloadFile(fileUUID, itemUUID, vaultUUID, targetDirectory string, overwrite bool) (string, error)
+	DownloadFile(file *onepassword.File, targetDirectory string, overwrite bool) (string, error)
 	LoadStructFromItemByTitle(config interface{}, itemTitle string, vaultUUID string) error
 	LoadStructFromItem(config interface{}, itemUUID string, vaultUUID string) error
 	LoadStruct(config interface{}) error
@@ -443,11 +443,7 @@ func (rs *restClient) GetFileContent(file *onepassword.File) ([]byte, error) {
 	return content, nil
 }
 
-func (rs *restClient) DownloadFile(fileUUID, itemUUID, vaultUUID, targetDirectory string, overwrite bool) (string, error) {
-	file, err := rs.GetFile(fileUUID, itemUUID, vaultUUID)
-	if err != nil {
-		return "", err
-	}
+func (rs *restClient) DownloadFile(file *onepassword.File, targetDirectory string, overwriteIfExists bool) (string, error) {
 	response, err := rs.retrieveDocumentContent(file)
 	if err != nil {
 		return "", err
@@ -457,7 +453,7 @@ func (rs *restClient) DownloadFile(fileUUID, itemUUID, vaultUUID, targetDirector
 
 	var osFile *os.File
 
-	if overwrite {
+	if overwriteIfExists {
 		osFile, err = createFile(path)
 		if err != nil {
 			return "", err

--- a/connect/client.go
+++ b/connect/client.go
@@ -432,6 +432,9 @@ func (rs *restClient) GetFileContent(file *onepassword.File) ([]byte, error) {
 		return content, nil
 	}
 	response, err := rs.retrieveDocumentContent(file)
+	if err != nil {
+		return nil, err
+	}
 	content, err := readResponseBody(response, http.StatusOK)
 	if err != nil {
 		return nil, err
@@ -464,9 +467,7 @@ func (rs *restClient) DownloadFile(fileUUID, itemUUID, vaultUUID, targetDirector
 		return "", err
 	}
 
-	abs, err := filepath.Abs(path)
-
-	return abs, nil
+	return path, nil
 }
 
 func (rs *restClient) retrieveDocumentContent(file *onepassword.File) (*http.Response, error) {


### PR DESCRIPTION
This PR comes to another two methods related to file support, as to make this SDK consistent with what has already been implemented in the Python SDK.

Example usage:
```go
func main () {
        client := connect.NewClientFromEnvironment()
	items, err := client.GetFiles( "moakfcb36gamyftyq4asblffoy", "7turaasywpymt3jecxoxk5roli")
	if err != nil {
		log.Fatal(err)
	}
	path, err := client.DownloadFile(items[0], ".", true)
	if err != nil {
		log.Fatal(err)
	}
	fmt.Print(path)
}
```
Under this item, I have a `1password-credentials.json` file. After executing the above script, that makes use of the two newly implemented functions, this file can be found locally, in the current working directory.