### PR TITLE
Add skip action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     name: Build
     needs: pre_job
-      if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
     steps:
     - name: Set up Go 1.x

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@v3.4.1
+        with:
+          skip_after_successful_duplicate: 'true'
 
   build:
     name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,8 +4,18 @@ permissions:
 on: [push, pull_request]
 
 jobs:
+  pre_job:
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@v3.4.1
+
   build:
     name: Build
+    needs: pre_job
+      if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
     steps:
     - name: Set up Go 1.x

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,17 +4,14 @@ permissions:
 on: [push, pull_request]
 
 jobs:
-  pre_job:
-    runs-on: ubuntu-latest
-    outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
-    steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@v3.4.1
   build:
     name: Build
-    needs: pre_job
-    if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
+    if: >-
+      ${{
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'push' &&
+      github.event.pull_request.head.repo.full_name != '1Password/connect-sdk-go')
+      }}
     runs-on: ubuntu-latest
     steps:
     - name: Set up Go 1.x

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,9 +11,6 @@ jobs:
     steps:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@v3.4.1
-        with:
-          skip_after_successful_duplicate: 'true'
-
   build:
     name: Build
     needs: pre_job


### PR DESCRIPTION
This PR ensures that duplicate jobs are not run, in case `push` and `pull request` events are triggered concomitantly.