### PR TITLE
Export File.Content, Support Creating Document type

### DIFF
--- a/connect/client.go
+++ b/connect/client.go
@@ -481,8 +481,8 @@ func (rs *restClient) GetFile(uuid string, itemUUID string, vaultUUID string) (*
 // GetFileContent retrieves the file's content.
 // If the file's content have previously been fetched, those contents are returned without making another request.
 func (rs *restClient) GetFileContent(file *onepassword.File) ([]byte, error) {
-	if content, err := file.Content(); err == nil {
-		return content, nil
+	if file.IsFetched() {
+		return file.Content, nil
 	}
 	response, err := rs.retrieveDocumentContent(file)
 	if err != nil {
@@ -492,7 +492,7 @@ func (rs *restClient) GetFileContent(file *onepassword.File) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	file.SetContent(content)
+	file.Content = content
 	return content, nil
 }
 

--- a/onepassword/files.go
+++ b/onepassword/files.go
@@ -2,7 +2,6 @@ package onepassword
 
 import (
 	"encoding/json"
-	"errors"
 )
 
 type File struct {
@@ -11,7 +10,7 @@ type File struct {
 	Section     *ItemSection `json:"section,omitempty"`
 	Size        int          `json:"size"`
 	ContentPath string       `json:"content_path"`
-	content     []byte
+	Content     []byte       `json:"content,omitempty"`
 }
 
 func (f *File) UnmarshalJSON(data []byte) error {
@@ -23,6 +22,7 @@ func (f *File) UnmarshalJSON(data []byte) error {
 		ContentPath string       `json:"content_path"`
 		Content     []byte       `json:"content,omitempty"`
 	}
+
 	if err := json.Unmarshal(data, &jsonFile); err != nil {
 		return err
 	}
@@ -31,19 +31,15 @@ func (f *File) UnmarshalJSON(data []byte) error {
 	f.Section = jsonFile.Section
 	f.Size = jsonFile.Size
 	f.ContentPath = jsonFile.ContentPath
-	f.content = jsonFile.Content
+	f.Content = jsonFile.Content
 	return nil
 }
 
-// Content returns the content of the file if they have been loaded and returns an error if they have not been loaded.
-// Use `client.GetFileContent(file *File)` instead to make sure the content is fetched automatically if not present.
-func (f *File) Content() ([]byte, error) {
-	if f.content == nil {
-		return nil, errors.New("file content not loaded")
+// IsFetched returns true if the content of the file has been loaded and false if not.
+// Use `client.GetFileContent(file *File)` to make sure the content is fetched automatically if not present.
+func (f *File) IsFetched() bool {
+	if f.Content == nil {
+		return false
 	}
-	return f.content, nil
-}
-
-func (f *File) SetContent(content []byte) {
-	f.content = content
+	return true
 }


### PR DESCRIPTION
See https://github.com/1Password/connect-sdk-go/issues/45.

This converts the unexported `File.content` to `File.Content`, so that `json.Marshal` will include it so that `CreateItem(itemWithFile)` will work.

Exporting it created a conflict with the `Content` method. I converted the method to `IsFetched`, but if you'd prefer I could just rename it `GetContent` and put the get-else-error logic back.