### PR TITLE
Improve fetching a vault by either name or UUID

### DIFF
--- a/connect/client.go
+++ b/connect/client.go
@@ -35,6 +35,7 @@ var (
 type Client interface {
 	GetVaults() ([]onepassword.Vault, error)
 	GetVault(uuid string) (*onepassword.Vault, error)
+	GetVaultByUUID(uuid string) (*onepassword.Vault, error)
 	GetVaultsByTitle(uuid string) ([]onepassword.Vault, error)
 	GetItem(uuid string, vaultUUID string) (*onepassword.Item, error)
 	GetItems(vaultUUID string) ([]onepassword.Item, error)
@@ -155,7 +156,7 @@ func (rs *restClient) GetVaultByUUID(uuid string) (*onepassword.Vault, error) {
 		return nil, vaultUUIDError
 	}
 
-	span := rs.tracer.StartSpan("GetVault")
+	span := rs.tracer.StartSpan("GetVaultByUUID")
 	defer span.Finish()
 
 	vaultURL := fmt.Sprintf("/v1/vaults/%s", uuid)

--- a/connect/client_test.go
+++ b/connect/client_test.go
@@ -203,12 +203,40 @@ func Test_restClient_GetVault(t *testing.T) {
 	assert.Equal(t, expectedVault, vault, "retrieved vault is not as expected")
 }
 
-func Test_restClient_GetVaultEmptyUUID(t *testing.T) {
+func Test_restClient_GetVaultByID(t *testing.T) {
+	expectedVault := &onepassword.Vault{
+		Name:        "Test vault",
+		Description: "Test Vault description",
+		ID:          testID,
+	}
+
+	mockHTTPClient.Dofunc = getVault(expectedVault)
+	vault, err := testClient.GetVaultByUUID(expectedVault.ID)
+
+	assert.Nil(t, err)
+	assert.Equal(t, expectedVault, vault, "retrieved vault is not as expected")
+}
+
+func Test_restClient_GetVaultByTitle(t *testing.T) {
+	expectedVault := &onepassword.Vault{
+		Name:        "Test vault",
+		Description: "Test Vault description",
+		ID:          testID,
+	}
+
+	mockHTTPClient.Dofunc = listVaults
+	vault, err := testClient.GetVaultByTitle(expectedVault.Name)
+
+	assert.Nil(t, err)
+	assert.Equal(t, expectedVault, vault, "retrieved vault is not as expected")
+}
+
+func Test_restClient_GetVaultEmptyQuery(t *testing.T) {
 	errResult := apiError(http.StatusNotFound, "Vault not found")
 	mockHTTPClient.Dofunc = respondError(errResult)
 	_, err := testClient.GetVault("")
 
-	assert.EqualError(t, err, "malformed vault uuid provided")
+	assert.EqualError(t, err, "Please provide either the vault name or its ID.")
 }
 
 func Test_restClient_GetVaultError(t *testing.T) {
@@ -500,7 +528,8 @@ func respondError(apiErr *onepassword.Error) func(req *http.Request) (*http.Resp
 func listVaults(req *http.Request) (*http.Response, error) {
 	vaults := []onepassword.Vault{
 		{
-			Description: "Test Vault",
+			Name:        "Test vault",
+			Description: "Test Vault description",
 			ID:          testID,
 		},
 	}


### PR DESCRIPTION
With this improvement, we have the following functionality:
- `GetVault` - returns a vault either by its name or UUID
- `GetVaultByUUID` - returns a vault based on the UUID
- `GetVaultByTitle` - returns a vault based on the title

This will enable the users to get the vault by the title as well, and use `GetVault` with vault names as well.