### PR TITLE
Update ItemURL struct

### DIFF
--- a/onepassword/items.go
+++ b/onepassword/items.go
@@ -84,6 +84,7 @@ type ItemVault struct {
 // ItemURL is a simplified item URL
 type ItemURL struct {
 	Primary bool   `json:"primary,omitempty"`
+	Label   string `json:"label,omitempty"`
 	URL     string `json:"href"`
 }
 


### PR DESCRIPTION
With the new improvements to the Connect response, we can now get the autofill URL's label. The SDK should reflect this improvement.