### PR TITLE
Enable functions to accept item/vault titles and UUIDs as parameters

### DIFF
--- a/connect/client_test.go
+++ b/connect/client_test.go
@@ -280,6 +280,21 @@ func Test_restClient_GetItem(t *testing.T) {
 	}
 }
 
+func Test_restClient_GetItemByUUID(t *testing.T) {
+	mockHTTPClient.Dofunc = getItem
+	item, err := testClient.GetItemByUUID(testID, testID)
+
+	if err != nil {
+		t.Logf("Unable to get items: %s", err.Error())
+		t.FailNow()
+	}
+
+	if item == nil {
+		t.Log("Expected 1 item to exist")
+		t.FailNow()
+	}
+}
+
 func Test_restClient_GetItemNotFound(t *testing.T) {
 	errResult := apiError(http.StatusNotFound, "item not found")
 	mockHTTPClient.Dofunc = respondError(errResult)


### PR DESCRIPTION
This PR brings the following enhancements:
- `GetItem` now accepts as parameters item title/UUID and vault title/UUID
- `GetItemByUUID` is added for getting an item based on its UUID
- `GetItemByTitle` now accepts as parameter a vault title or UUID
- `GetItemsByTitle` now accepts as parameter a vault title or UUID
- `GetItems` now accepts as parameter a vault title or UUID
- `CreateItem` now accepts as parameter a vault title or UUID
- `DeleteItemByID` now accepts as parameter a vault title or UUID
- `GetFile` now accepts as parameters item title/UUID and vault title/UUID
- `GetFiles` now accepts as parameters item title/UUID and vault title/UUID
- `LoadStructFromItem` now accepts as parameters item title/UUID and vault title/UUID
- `LoadStructFromItemByUUID` is added for getting an item based on its UUID
- `LoadStructFromItemByTitle` now accepts as parameter a vault title or UUID