### PR TITLE
Add support for `excludeCharacters` to field recipe

### DIFF
--- a/onepassword/items.go
+++ b/onepassword/items.go
@@ -96,8 +96,9 @@ type ItemSection struct {
 
 // GeneratorRecipe Representation of a "recipe" used to generate a field
 type GeneratorRecipe struct {
-	Length        int      `json:"length,omitempty"`
-	CharacterSets []string `json:"characterSets,omitempty"`
+	Length            int      `json:"length,omitempty"`
+	CharacterSets     []string `json:"characterSets,omitempty"`
+	ExcludeCharacters string   `json:"excludeCharacters,omitempty"`
 }
 
 // ItemField Representation of a single field on an Item


### PR DESCRIPTION
Adds SDK support for the `excludeCharacters` option when configuring the field generator with a recipe.

As of Connect v1.4.0, the user can provide a string of excluded characters that the field generator must omit. Because this option is noted in the spec, we need to support it in our SDKs, too.