### PR TITLE
Use contentPath instead of content_path

### DIFF
--- a/onepassword/files.go
+++ b/onepassword/files.go
@@ -10,7 +10,7 @@ type File struct {
 	Name        string       `json:"name"`
 	Section     *ItemSection `json:"section,omitempty"`
 	Size        int          `json:"size"`
-	ContentPath string       `json:"content_path"`
+	ContentPath string       `json:"contentPath"`
 	content     []byte
 }
 
@@ -20,7 +20,7 @@ func (f *File) UnmarshalJSON(data []byte) error {
 		Name        string       `json:"name"`
 		Section     *ItemSection `json:"section,omitempty"`
 		Size        int          `json:"size"`
-		ContentPath string       `json:"content_path"`
+		ContentPath string       `json:"contentPath"`
 		Content     []byte       `json:"content,omitempty"`
 	}
 	if err := json.Unmarshal(data, &jsonFile); err != nil {


### PR DESCRIPTION
The API docs say `content_path`, but Connect Server is sending `contentPath`.

You may want to fix it on the Connect Server side instead, in which case we can close this PR.  

I tested against Connect Server v1.5.4.