### PR TITLE
return error with proper message and status if the response body is n…

### DIFF
--- a/connect/client.go
+++ b/connect/client.go
@@ -845,11 +845,16 @@ func readResponseBody(resp *http.Response, expectedStatusCode int) ([]byte, erro
 		return nil, err
 	}
 	if resp.StatusCode != expectedStatusCode {
-		var errResp *onepassword.Error
-		if err := json.Unmarshal(body, &errResp); err != nil {
-			return nil, fmt.Errorf("decoding error response: %s", err)
+		var errResp onepassword.Error
+		if json.Valid(body) {
+			if err := json.Unmarshal(body, &errResp); err != nil {
+				return nil, fmt.Errorf("decoding error response: %s", err)
+			}
+		} else {
+			errResp.StatusCode = resp.StatusCode
+			errResp.Message = http.StatusText(resp.StatusCode)
 		}
-		return nil, errResp
+		return nil, &errResp
 	}
 	return body, nil
 }

--- a/connect/client_test.go
+++ b/connect/client_test.go
@@ -307,6 +307,18 @@ func Test_restClient_GetItemNotFound(t *testing.T) {
 	}
 }
 
+func Test_restClient_GetItemFailWithNotJsonBody(t *testing.T) {
+	errResult := apiError(http.StatusBadGateway, http.StatusText(http.StatusBadGateway))
+	mockHTTPClient.Dofunc = respondErrorWithHtmlBody(errResult)
+	item, err := testClient.GetItem(testID, testID)
+
+	assert.ErrorIs(t, err, errResult)
+	if item != nil {
+		t.Log("Expected no items returns")
+		t.FailNow()
+	}
+}
+
 func Test_restClient_GetItems(t *testing.T) {
 	mockHTTPClient.Dofunc = listItems
 	items, err := testClient.GetItems(testID)
@@ -597,6 +609,18 @@ func respondError(apiErr *onepassword.Error) func(req *http.Request) (*http.Resp
 			StatusCode: apiErr.StatusCode,
 			Header:     req.Header,
 			Body:       ioutil.NopCloser(bytes.NewReader(body)),
+		}, nil
+	}
+}
+
+func respondErrorWithHtmlBody(apiErr *onepassword.Error) func(req *http.Request) (*http.Response, error) {
+	return func(req *http.Request) (*http.Response, error) {
+		body := "<html></html>"
+		return &http.Response{
+			Status:     http.StatusText(apiErr.StatusCode),
+			StatusCode: apiErr.StatusCode,
+			Header:     req.Header,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte(body))),
 		}, nil
 	}
 }


### PR DESCRIPTION
Resolves: #63 

**Problem:**
If response has not valid json body, sdk returns unmarshal error.

**Solution:**
Check whether request body is valid json and return response status and message is not.