### PR TITLE
Account for cases where there is a 26 char name

### DIFF
--- a/connect/client.go
+++ b/connect/client.go
@@ -246,10 +246,14 @@ func (rs *restClient) GetItem(itemQuery string, vaultQuery string) (*onepassword
 	if itemQuery == "" {
 		return nil, fmt.Errorf("Please provide either the item name or its ID.")
 	}
-	if !isValidUUID(itemQuery) {
-		return rs.GetItemByTitle(itemQuery, vaultQuery)
+
+	if isValidUUID(itemQuery) {
+		item, err := rs.GetItemByUUID(itemQuery, vaultQuery)
+		if item != nil {
+			return item, err
+		}
 	}
-	return rs.GetItemByUUID(itemQuery, vaultQuery)
+	return rs.GetItemByTitle(itemQuery, vaultQuery)
 }
 
 // GetItemByUUID Get a specific Item from the 1Password Connect API by its UUID

--- a/onepassword/vaults.go
+++ b/onepassword/vaults.go
@@ -12,7 +12,7 @@ type Vault struct {
 	Description string `json:"description,omitempty"`
 
 	AttrVersion    int       `json:"attributeVersion,omitempty"`
-	ContentVersoin int       `json:"contentVersion,omitempty"`
+	ContentVersion int       `json:"contentVersion,omitempty"`
 	Items          int       `json:"items,omitempty"`
 	Type           VaultType `json:"type,omitempty"`
 


### PR DESCRIPTION
Added logic to fallback on getItemByTitle is getItemByUUID returns a nil item for the cases where the item title is exactly 26 chars