### PR TITLE
Fixed expected field type for ssh private keys

### DIFF
--- a/onepassword/items.go
+++ b/onepassword/items.go
@@ -56,7 +56,7 @@ const (
 	FieldTypeString           ItemFieldType = "STRING"
 	FieldTypeURL              ItemFieldType = "URL"
 	FieldTypeFile             ItemFieldType = "FILE"
-	FieldTypeSSHKey           ItemFieldType = "SSH_KEY"
+	FieldTypeSSHKey           ItemFieldType = "SSHKEY"
 	FieldTypeUnknown          ItemFieldType = "UNKNOWN"
 )
 


### PR DESCRIPTION
Changed the expected field type for an SSH private key field to `SSHKEY` from `SSH_KEY` as the 1Password stores the type as `SSHKEY`.