### PR TITLE
Bump actions for Node 20 EOL

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,12 +9,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set up Go 1.x
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v6
       with:
         go-version: ^1.20
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
 
     - name: Build
       run: go build -v ./...

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - id: is_release_branch_without_pr
         name: Find matching PR
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -46,7 +46,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Parse release version
         id: get_version
@@ -78,7 +78,7 @@ jobs:
 
       - name: Create Pull Request via API
         id: post_pr
-        uses: octokit/request-action@v2.x
+        uses: octokit/request-action@v3
         with:
           route: POST /repos/${{ github.repository }}/pulls
           title: ${{ format('Prepare Release - v{0}', steps.get_version.outputs.version) }}


### PR DESCRIPTION
## What's Changed

Updates actions to handle Node 20 EOL. Update to use new versions with Node 24.

actions/github-script -> [v8](https://github.com/actions/github-script/releases/tag/v8)
actions/checkout -> v6 ([v5 ](https://github.com/actions/checkout/releases/tag/v5.0.0)had upgrade)
octokit/request-action -> [v3](https://github.com/octokit/request-action/releases/tag/v3.0.0)
actions/setup-go -> [v6](https://github.com/actions/setup-go/releases/tag/v6.2.0)

