### PR TITLE
Fix case-sensitive section/URL label matching in config_helper (#99)

### DIFF
--- a/connect/client_test.go
+++ b/connect/client_test.go
@@ -598,6 +598,42 @@ func Test_restClient_loadStructFromItemAndOneItem(t *testing.T) {
 	assert.Equal(t, generateComplexItem(testVaultUUID), c.Item)
 }
 
+// Test_restClient_loadStructFromItem_caseInsensitiveTags verifies that
+// section, field, and url tag values resolve case-insensitively against the
+// labels stored in 1Password. Item labels in 1Password may be mixed-case,
+// but a struct tag should still resolve them regardless of casing.
+func Test_restClient_loadStructFromItem_caseInsensitiveTags(t *testing.T) {
+	type testConfig struct {
+		Username string                  `opfield:"USERNAME"`                     // field label is "username" lowercase
+		Password string                  `opsection:"SECTION" opfield:"PASSWORD"` // section/field labels are lowercase
+		Section  onepassword.ItemSection `opsection:"SECTION"`                    // section label is lowercase
+		URL      onepassword.ItemURL     `opurl:"URL"`                            // url label is lowercase
+	}
+	mockHTTPClient.Dofunc = getComplexItem
+
+	item := parsedItem{
+		vaultUUID: testID,
+		itemUUID:  testID,
+	}
+	c := testConfig{}
+
+	err := loadToStruct(&item, reflect.ValueOf(&c).Elem())
+	assert.Nil(t, err)
+	err = setValuesForTag(testClient, &item, false)
+	assert.Nil(t, err)
+
+	assert.Equal(t, "wendy", c.Username)
+	assert.Equal(t, "appleseed", c.Password)
+	assert.Equal(t, onepassword.ItemSection{
+		ID:    "",
+		Label: "section",
+	}, c.Section)
+	assert.Equal(t, onepassword.ItemURL{
+		Label: "url",
+		URL:   "https://www.appleseed.com",
+	}, c.URL)
+}
+
 func respondError(apiErr *onepassword.Error) func(req *http.Request) (*http.Response, error) {
 	return func(req *http.Request) (*http.Response, error) {
 		body, err := json.Marshal(apiErr)

--- a/connect/config_helper.go
+++ b/connect/config_helper.go
@@ -108,7 +108,7 @@ func setValuesForTag(client Client, parsedItem *parsedItem, byTitle bool) error 
 				fieldSectionID = f.Section.ID
 			}
 
-			if fieldSectionID == sectionID && f.Label == field.Tag.Get(fieldTag) {
+			if fieldSectionID == sectionID && strings.EqualFold(f.Label, field.Tag.Get(fieldTag)) {
 				if err := setValue(value, f.Value); err != nil {
 					return err
 				}
@@ -143,7 +143,7 @@ func sectionIDForName(name string, sections []*onepassword.ItemSection) string {
 	}
 
 	for _, s := range sections {
-		if name == strings.ToLower(s.Label) {
+		if strings.EqualFold(name, s.Label) {
 			return s.ID
 		}
 	}
@@ -157,7 +157,7 @@ func sectionLabelForName(name string, sections []*onepassword.ItemSection) strin
 	}
 
 	for _, s := range sections {
-		if name == strings.ToLower(s.Label) {
+		if strings.EqualFold(name, s.Label) {
 			return s.Label
 		}
 	}
@@ -171,7 +171,7 @@ func urlPrimaryForName(name string, itemURLs []onepassword.ItemURL) bool {
 	}
 
 	for _, url := range itemURLs {
-		if url.Label == strings.ToLower(name) {
+		if strings.EqualFold(name, url.Label) {
 			return url.Primary
 		}
 	}
@@ -185,7 +185,7 @@ func urlLabelForName(name string, itemURLs []onepassword.ItemURL) string {
 	}
 
 	for _, url := range itemURLs {
-		if url.Label == strings.ToLower(name) {
+		if strings.EqualFold(name, url.Label) {
 			return url.Label
 		}
 	}
@@ -199,7 +199,7 @@ func urlURLForName(name string, itemURLs []onepassword.ItemURL) string {
 	}
 
 	for _, url := range itemURLs {
-		if url.Label == strings.ToLower(name) {
+		if strings.EqualFold(name, url.Label) {
 			return url.URL
 		}
 	}

--- a/connect/config_helper_test.go
+++ b/connect/config_helper_test.go
@@ -1,0 +1,153 @@
+package connect
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/1Password/connect-sdk-go/onepassword"
+)
+
+// Tests in this file exercise the section/URL name lookup helpers in
+// config_helper.go. The lookups must be case-insensitive: a struct tag like
+// `opsection:"Details"` should match a section whose label is "Details",
+// "details", or any other casing. Prior to the fix, comparisons used
+// strings.ToLower on one side only, which silently dropped fields whenever
+// the tag's case did not match the lowercased label.
+
+var testSections = []*onepassword.ItemSection{
+	{ID: "section-id-1", Label: "Details"},
+	{ID: "section-id-2", Label: "API Credentials"},
+	{ID: "section-id-3", Label: "lowercase"},
+}
+
+var testURLs = []onepassword.ItemURL{
+	{Label: "Primary", URL: "https://example.com", Primary: true},
+	{Label: "Backup", URL: "https://backup.example.com", Primary: false},
+}
+
+func TestSectionIDForName(t *testing.T) {
+	tests := []struct {
+		name string
+		tag  string
+		want string
+	}{
+		{"exact case", "Details", "section-id-1"},
+		{"lowercase tag against mixed-case label", "details", "section-id-1"},
+		{"uppercase tag against mixed-case label", "DETAILS", "section-id-1"},
+		{"mixed-case tag against mixed-case label", "DeTaIlS", "section-id-1"},
+		{"label with space, lowercase tag", "api credentials", "section-id-2"},
+		{"label with space, exact case", "API Credentials", "section-id-2"},
+		{"lowercase label, lowercase tag", "lowercase", "section-id-3"},
+		{"lowercase label, uppercase tag", "LOWERCASE", "section-id-3"},
+		{"no match", "nonexistent", ""},
+		{"empty tag", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, sectionIDForName(tt.tag, testSections))
+		})
+	}
+}
+
+func TestSectionIDForName_NilSections(t *testing.T) {
+	assert.Equal(t, "", sectionIDForName("Details", nil))
+}
+
+func TestSectionIDForName_EmptySections(t *testing.T) {
+	assert.Equal(t, "", sectionIDForName("Details", []*onepassword.ItemSection{}))
+}
+
+func TestSectionLabelForName(t *testing.T) {
+	tests := []struct {
+		name string
+		tag  string
+		want string
+	}{
+		{"exact case returns stored label", "Details", "Details"},
+		{"lowercase tag returns stored mixed-case label", "details", "Details"},
+		{"uppercase tag returns stored mixed-case label", "DETAILS", "Details"},
+		{"mixed-case tag returns stored mixed-case label", "DeTaIlS", "Details"},
+		{"label with space, lowercase tag", "api credentials", "API Credentials"},
+		{"no match", "nonexistent", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, sectionLabelForName(tt.tag, testSections))
+		})
+	}
+}
+
+func TestSectionLabelForName_NilSections(t *testing.T) {
+	assert.Equal(t, "", sectionLabelForName("Details", nil))
+}
+
+func TestURLPrimaryForName(t *testing.T) {
+	tests := []struct {
+		name string
+		tag  string
+		want bool
+	}{
+		{"exact case primary URL", "Primary", true},
+		{"lowercase tag against mixed-case label, primary", "primary", true},
+		{"uppercase tag against mixed-case label, primary", "PRIMARY", true},
+		{"exact case non-primary URL", "Backup", false},
+		{"lowercase tag against mixed-case label, non-primary", "backup", false},
+		{"no match returns false", "nonexistent", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, urlPrimaryForName(tt.tag, testURLs))
+		})
+	}
+}
+
+func TestURLPrimaryForName_NilURLs(t *testing.T) {
+	assert.Equal(t, false, urlPrimaryForName("Primary", nil))
+}
+
+func TestURLLabelForName(t *testing.T) {
+	tests := []struct {
+		name string
+		tag  string
+		want string
+	}{
+		{"exact case", "Primary", "Primary"},
+		{"lowercase tag returns stored mixed-case label", "primary", "Primary"},
+		{"uppercase tag returns stored mixed-case label", "PRIMARY", "Primary"},
+		{"mixed-case tag returns stored mixed-case label", "PrImArY", "Primary"},
+		{"no match", "nonexistent", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, urlLabelForName(tt.tag, testURLs))
+		})
+	}
+}
+
+func TestURLLabelForName_NilURLs(t *testing.T) {
+	assert.Equal(t, "", urlLabelForName("Primary", nil))
+}
+
+func TestURLURLForName(t *testing.T) {
+	tests := []struct {
+		name string
+		tag  string
+		want string
+	}{
+		{"exact case", "Primary", "https://example.com"},
+		{"lowercase tag against mixed-case label", "primary", "https://example.com"},
+		{"uppercase tag against mixed-case label", "PRIMARY", "https://example.com"},
+		{"non-primary URL, lowercase tag", "backup", "https://backup.example.com"},
+		{"no match", "nonexistent", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, urlURLForName(tt.tag, testURLs))
+		})
+	}
+}
+
+func TestURLURLForName_NilURLs(t *testing.T) {
+	assert.Equal(t, "", urlURLForName("Primary", nil))
+}


### PR DESCRIPTION
Fixes #99.

Per @JillRegan's [comment on #99](https://github.com/1Password/connect-sdk-go/issues/99#issuecomment-2700000000), the fix is to swap `name == strings.ToLower(s.Label)` for `strings.EqualFold(name, s.Label)` in `sectionIDForName`. While implementing, I noticed the same case-sensitive comparison pattern in four other sites in the same file plus one inline comparison in `setValuesForTag`. They're all the same bug class — user-supplied struct tag values matched case-sensitively against 1Password-stored labels — so I included them all. **Happy to split into a smaller PR if you'd prefer to land just the section helpers.**

## Bug

In `connect/config_helper.go`, comparisons of struct-tag values against 1Password labels lowercase only one side, so any mixed-case label silently fails to match:

```go
if name == strings.ToLower(s.Label) { ... }    // sections — lowercases label only
if url.Label == strings.ToLower(name) { ... }  // urls — lowercases tag only (mirror image)
if f.Label == field.Tag.Get(fieldTag) { ... }  // fields — no lowercase at all (case-sensitive)
```

A user with the struct:

```go
type Config struct {
    Host string `opsection:"Details" opfield:"hostname"`
}
```

— and a section actually named `"Details"` in 1Password — gets `Host = ""` silently. The reporter noticed this for `opsection`; the same class of bug exists for `opurl` (mirror direction) and for `opfield` (no lowercasing at all).

## Fix

All five comparison sites now use `strings.EqualFold(tag, label)`:

- Idiomatic Go for case-insensitive string comparison
- No allocations (vs. `strings.ToLower` which allocates a new string on each call)
- Correctly handles Unicode case folding (e.g. Turkish dotted/dotless I)

## Tests

- **New `connect/config_helper_test.go`** — table-driven unit tests for all five helpers (`sectionIDForName`, `sectionLabelForName`, `urlPrimaryForName`, `urlLabelForName`, `urlURLForName`). Covers exact-case, lowercase, uppercase, mixed-case, no-match, nil, and empty cases. 32 sub-tests total.
- **New `Test_restClient_loadStructFromItem_caseInsensitiveTags`** in `connect/client_test.go` — end-to-end test exercising `setValuesForTag` with `UPPERCASE` and mixed-case tags against the existing `getComplexItem` fixture (which uses lowercase labels). Catches the field-label fix in `setValuesForTag` that the unit tests can't reach.
- Verified each test fails against the unfixed code; 19 of the new sub-tests catch the bug. The others are lowercase-only happy paths that the bug doesn't affect.

## Pre-flight checks

- `go test ./...` — pass
- `go test -race ./...` — pass
- `gofmt -l ./...` — clean
- `go vet ./...` — clean
- Bug-demo verified: reverting any subset of the fix causes the corresponding tests to fail
